### PR TITLE
Fix CLI installed with `npm` (add shebang)

### DIFF
--- a/bin/cmioc.ts
+++ b/bin/cmioc.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { Command, InvalidArgumentError } from "@commander-js/extra-typings";
 import {
     Address,


### PR DESCRIPTION
Thanks, @edubart for reporting this bug.

```
/home/bart/.npm_modules/bin/cmioc: line 1: use strict: command not found
/home/bart/.npm_modules/bin/cmioc: line 2: syntax error near unexpected token `exports,'
/home/bart/.npm_modules/bin/cmioc: line 2: `Object.defineProperty(exports, "__esModule", { value: true });'
```